### PR TITLE
Toolchain support

### DIFF
--- a/app.pl
+++ b/app.pl
@@ -108,10 +108,11 @@ get '/dl/:product' => sub {
             push @data, {
                 name      => $bin->name,
                 ver       => $bin->ver,
-                build_rev => $bin->build_rev,
+               (build_rev => $bin->build_rev) x!! $bin->build_rev,
                 platform  => $bin->platform,
-                arch      => $bin->arch,
-                backend   => $bin->backend,
+               (arch      => $bin->arch)      x!! $bin->arch,
+               (toolchain => $bin->toolchain) x!! $bin->toolchain,
+               (backend   => $bin->backend)   x!! $bin->backend,
                 type      => $bin->type,
                 format    => $format,
                 latest    => $ver->latest,
@@ -242,8 +243,8 @@ helper items_in => sub {
     return @$what;
 };
 helper latest_version => sub {
-    my ($self, $product, $platform, $arch, $type) = @_;
-    my @bins = $binaries->latest($product, $platform, $arch, $type);
+    my ($self, $product, $platform, $arch, $type, $toolchain) = @_;
+    my @bins = $binaries->latest($product, $platform, $arch, $type, $toolchain);
     return $bins[0];
 };
 

--- a/lib/Perl6Org/Binaries.pm
+++ b/lib/Perl6Org/Binaries.pm
@@ -13,13 +13,13 @@ use Perl6Org::Binaries::Ver;
 has 'binaries_dir';
 
 sub all {
-    my ($self, $product, $platform, $arch, $type) = @_;
+    my ($self, $product, $platform, $arch, $type, $toolchain) = @_;
     $product or die "Must specify product to fetch all binaries for";
 
     my $products = $self->products('as_hashref');
     $products->{$product} or die "Unknown product `$product`. "
         . 'Did you specify the correct binaries dir?';
-    $self->_get_vers_for($product, $platform, $arch, $type);
+    $self->_get_vers_for($product, $platform, $arch, $type, $toolchain);
 }
 
 sub platforms {
@@ -37,7 +37,7 @@ sub products {
 }
 
 sub latest {
-    my ($self, $product, $platform, $arch, $type) = @_;
+    my ($self, $product, $platform, $arch, $type, $toolchain) = @_;
 
     my $products = $self->products('as_hashref');
     $products->{$product} or die "Unknown product `$product`. "
@@ -47,7 +47,7 @@ sub latest {
     $platforms->{$platform} or die "Unknown platform `$platform`.";
 
     my @bins;
-    for my $ver ($self->all($product, $platform, $arch, $type)->each) {
+    for my $ver ($self->all($product, $platform, $arch, $type, $toolchain)->each) {
         next unless $ver->latest;
         for my $bin ($ver->bins->each) {
             push @bins, $bin;
@@ -67,7 +67,7 @@ sub bin {
 }
 
 sub _get_vers_for {
-    my ($self, $product, $platform_filter, $arch_filter, $type_filter) = @_;
+    my ($self, $product, $platform_filter, $arch_filter, $type_filter, $toolchain_filter) = @_;
 
     my $dir = catfile $self->binaries_dir, $product;
     my $prefix = 1 + length $dir;
@@ -83,16 +83,17 @@ sub _get_vers_for {
     for my $full_path (bsd_glob catfile $dir, '*') {
         my $file = substr $full_path, $prefix;
 
-        # Source archives: rakudo-2019.11.02.tar.gz
-        # Precompiled archives: rakudo-moar-2019.11.02-01-linux-x86_64.tar.gz
-        # Star Bundle: rakudo-star-2019.11.02-01-win-x86_64.msi
+        # Source archives:      rakudo-2019.11.02.tar.gz
+        # Precompiled archives: rakudo-moar-2019.11.02-01-linux-x86_64-gcc.tar.gz
         # Star Bundle src: rakudo-star-2019.11.02-01.tar.gz
-        unless ($file =~ /^(.+)[.-](\d{4}\.\d{2}(?:\.\d+)?)(?:-(\d\d)(?:-([^.-]+)-([^.-]+)(?:-[^.]+)?)?)?\..+$/) {
+        # Star Bundle:     rakudo-star-2019.11.02-01-win-x86_64-msvc.msi
+        # Releases prior to 2020.11 miss the toolchain bit.
+        unless ($file =~ /^(.+)[.-](\d{4}\.\d{2}(?:\.\d+)?)(?:-(\d\d)(?:-([^.-]+)-([^.-]+)(?:-([^.-]+))?(?:-[^.]+)?)?)?\..+$/) {
             warn "Strange filename \"$file\" on file $full_path; skipping";
             next;
         }
 
-        my ($name, $ver, $build_rev, $platform, $arch) = ($1, $2, $3, $4, $5);
+        my ($name, $ver, $build_rev, $platform, $arch, $toolchain) = ($1, $2, $3, $4, $5, $6);
 
         my $backend = '';
         if ($product eq 'rakudo') {
@@ -111,9 +112,20 @@ sub _get_vers_for {
             warn "Unknown platform on file $full_path; skipping";
             next;
         }
-        
+
+        if (!$toolchain && $platform ne 'src') {
+            # Releases prior to 2020.11 didn't have the toolchain in their name.
+            # So fill them in here. The toolchains didn't change until 2020.11 so we can tell what they were.
+            $toolchain =
+                $platform eq 'win'   ? 'msvc'  :
+                $platform eq 'macos' ? 'clang' :
+                $platform eq 'linux' ? 'gcc'   :
+                'gcc';
+        }
+
         next if $platform_filter && $platform_filter ne $platform;
         next if $arch_filter && $arch_filter ne $arch;
+        next if $toolchain_filter && $toolchain_filter ne $toolchain;
 
         my $ext;
         for my $e (keys $types{$platform}->%*) {
@@ -130,13 +142,23 @@ sub _get_vers_for {
 
         next if $type_filter && $type_filter ne $type;
 
-
-        my $default =
-            $platform eq 'win'   && $type eq 'installer' && $ext eq '.msi' ? 1 :
-            $platform eq 'macos' && $type eq 'installer' && $ext eq '.dmg' ? 1 :
-            $platform eq 'linux' && $type eq 'archive'                     ? 1 :
-            $platform eq 'src'   && $type eq 'archive'                     ? 1 :
-            0;
+        my $default = 0;
+        if ($product eq 'star') {
+            $default =
+                $platform eq 'win'   && $type eq 'installer' && $ext eq '.msi' ? 1 :
+                $platform eq 'macos' && $type eq 'installer' && $ext eq '.dmg' ? 1 :
+                $platform eq 'linux' && $type eq 'archive'                     ? 1 :
+                $platform eq 'src'   && $type eq 'archive'                     ? 1 :
+                0;
+        }
+        elsif ($product eq 'rakudo') {
+            $default =
+                $platform eq 'win'   && $type eq 'archive' && $toolchain eq 'msvc'  ? 1 :
+                $platform eq 'macos' && $type eq 'archive' && $toolchain eq 'clang' ? 1 :
+                $platform eq 'linux' && $type eq 'archive' && $toolchain eq 'gcc'   ? 1 :
+                $platform eq 'src'   && $type eq 'archive'                          ? 1 :
+                0;
+        }
 
         unless ($ver) {
             warn "Unknown version on file $full_path; skipping";
@@ -149,10 +171,11 @@ sub _get_vers_for {
             name      => $product,
             path      => catfile($product, $file),
             ver       => $ver,
-            build_rev => $build_rev,
+           (build_rev => $build_rev) x!! $build_rev,
             platform  => $platform,
-            arch      => $arch,
-           (backend   => $backend) x!! $backend,
+           (arch      => $arch)      x!! $arch,
+           (toolchain => $toolchain) x!! $toolchain,
+           (backend   => $backend)   x!! $backend,
             full_path => $full_path,
             type      => $type,
             default   => $default,

--- a/lib/Perl6Org/Binaries/Bin.pm
+++ b/lib/Perl6Org/Binaries/Bin.pm
@@ -2,7 +2,7 @@ package Perl6Org::Binaries::Bin;
 
 use Mojo::Base -base;
 use POSIX qw/floor  round  pow/;
-has [qw/bin  ext  name  full_path  path  ver  build_rev  platform  arch  type  default  backend/];
+has [qw/bin  ext  name  full_path  path  ver  build_rev  platform  arch  toolchain  type  default  backend/];
 
 my @types = qw/B KB MB GB TB PB/;
 sub size {

--- a/t/01-binaries-model.t
+++ b/t/01-binaries-model.t
@@ -4,11 +4,11 @@ use 5.026;
 use Test::Most tests =>
     4 # starting tests
     + 3 # different products
-        *(1 # product test
+        * (1 # product test
             + 5 # versions for each product
-                *5) # version tests
+                * 5) # version tests
     + 7 # binary tests
-      * (11*5), 'die'; # total binaries * number of versions
+      * (10*5), 'die'; # total binaries * number of versions
 use File::Temp qw/tempdir/;
 use File::Spec::Functions qw/catfile/;
 
@@ -93,10 +93,9 @@ sub setup_temp_binaries_dir {
                 "rakudo-star-$ver.tar.gz.sha256.txt",
                 "rakudo-star-$ver.tar.gz.asc",
                 "rakudo-star-$ver.tar.gz",
-                "rakudo-star-$ver-macos-x86_64.dmg",
-                "rakudo-star-$ver-win-x86_64.msi",
-                "rakudo-star-$ver-win-x86.msi",
-                "org.perl6.rakudo-star.$ver-linux-x86_64.AppImage";
+                "rakudo-star-$ver-01-macos-x86_64.dmg",
+                "rakudo-star-$ver-01-win-x86_64.msi",
+                "rakudo-star-$ver-01-win-x86.msi",
         }
         for (@bins) {
             open my $fh_bin, '>', $_ or die "Failed to create $_: $!";

--- a/t/01-binaries-model.t
+++ b/t/01-binaries-model.t
@@ -93,9 +93,9 @@ sub setup_temp_binaries_dir {
                 "rakudo-star-$ver.tar.gz.sha256.txt",
                 "rakudo-star-$ver.tar.gz.asc",
                 "rakudo-star-$ver.tar.gz",
-                "rakudo-star-$ver-01-macos-x86_64.dmg",
-                "rakudo-star-$ver-01-win-x86_64.msi",
-                "rakudo-star-$ver-01-win-x86.msi",
+                "rakudo-star-$ver-01-macos-x86_64-clang.dmg",
+                "rakudo-star-$ver-01-win-x86_64-msvc.msi",
+                "rakudo-star-$ver-01-win-x86-msvc.msi",
         }
         for (@bins) {
             open my $fh_bin, '>', $_ or die "Failed to create $_: $!";


### PR DESCRIPTION
Related to rakudo/rakudo#3996. This adds support for prebuilt binary releases to include the toolchain in their name. Older archives which don't specify their toolchain are still recognized. The minimal API at `/dl/rakudo` is extended to also tell the toolchain of the respective file. If there are prebuilt archives with the same platform, but different toolchains provided the API will list the following files first:

- On Windows: MSVC
- On MacOS: clang
- On Linux: GCC

This is relevant for rakubrew which will use the first file presented to it by the API.

This prepares us for releasing prebuilt archives with different toolchains for the same platform. The most interest currently seems to be in GCC on Windows.