### PR TITLE
Add MacPort option to macos download tab

### DIFF
--- a/templates/downloads.html.ep
+++ b/templates/downloads.html.ep
@@ -122,6 +122,10 @@
       <h4>Homebrew</h4>
       <p>There is a  Homebrew package available:<br/>
       <code>brew install rakudo</code></p>
+
+      <h4>MacPorts</h4>
+      <p>There is a rakudo MacPort available:<br/>
+      <code>sudo port install rakudo</code></p>
     </div>
 
     <input type="radio" id="download-tab-javascript" name="tab-group-download">


### PR DESCRIPTION
Hi all - Simple addition to the macos tab of the downloads page highlighting that there is a MacPort available.
I've also submitted a PR to the macports crew to bring the port up-to-date (currently on 2020.12).
Regards, Martin