### PR TITLE
Update downloads.html.ep

### DIFF
--- a/templates/downloads.html.ep
+++ b/templates/downloads.html.ep
@@ -39,7 +39,7 @@
       </p>
       <a class="btn btn-dark kick-b" href="<%= url_for 'downloads-rakudo' %>">All releases</a>
       
-      <h4>SCOOP</h4>
+      <h5>Use a package manager to install the binary release</h5>
 
       <p>Install Rakudo-on-MoarVM with scoop:
       <code>scoop install rakudo-moar</code></p>

--- a/templates/downloads.html.ep
+++ b/templates/downloads.html.ep
@@ -41,7 +41,7 @@
       
       <h5>Use a package manager to install the binary release</h5>
 
-      <p>Install Rakudo-on-MoarVM with scoop:
+      <p>Install Rakudo-on-MoarVM with Scoop:
       <code>scoop install rakudo-moar</code></p>
       <a class="btn btn-dark" href="https://scoop.sh/">Scoop</a>
       

--- a/templates/downloads.html.ep
+++ b/templates/downloads.html.ep
@@ -38,7 +38,13 @@
       % }
       </p>
       <a class="btn btn-dark kick-b" href="<%= url_for 'downloads-rakudo' %>">All releases</a>
+      
+      <h4>SCOOP</h4>
 
+      <p>Install Rakudo-on-MoarVM with scoop:
+      <code>scoop install rakudo-moar</code></p>
+      <a class="btn btn-dark" href="https://scoop.sh/">Scoop</a>
+      
       <h4>Rakudo Star Bundle</h4>
 
       <p>This is a packaging of Rakudo itself, MoarVM, NQP and the modules of the Rakudo Star Bundle

--- a/templates/downloads.html.ep
+++ b/templates/downloads.html.ep
@@ -56,7 +56,7 @@
       <a class="btn btn-dark" href="https://chocolatey.org/packages/rakudostar">Chocolatey</a>
       
       <h5>Scoop</h5>
-      <p>Install the Rakudo Star Bundle with scoop:
+      <p>Install the Rakudo Star Bundle with Scoop:
       <code>scoop install rakudo-star</code></p>
       <a class="btn btn-dark" href="https://scoop.sh/">Scoop</a>
       


### PR DESCRIPTION
Within the "Downloads" -> "Windows" section, add the hint about the possibility to install the latest and greatest Rakudo-Moar package via SCOOP (and therefore having Rakudo always up2datge)