### PR TITLE
Assorted fixes

### DIFF
--- a/app.pl
+++ b/app.pl
@@ -208,11 +208,15 @@ helper make_crumbs => sub {
 };
 
 my %exts = qw/
-    .gz source  .msi windows  .exe windows
+    .gz source  .msi windows  .exe windows    .zip windows
     .dmg macos  .AppImage macos   .asc sig    .txt sig
 /;
 helper icon_for => sub {
     my ($self, $path) = @_;
+    return 'sig'   if $path =~ /\.asc$|\.txt$/;
+    return 'linux' if $path =~ /linux/;
+    return 'macos' if $path =~ /macos/;
+    return 'win'   if $path =~ /windows/;
     $exts{($path =~ /(.[^.]+)$/)[0]//''}//''
 };
 helper third_party => sub {

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -543,6 +543,10 @@ pre, code {
     background-image: url(/asset/pics/os-icon-windows.png)
 }
 
+[class^="file-icon-linux"] {
+    background-image: url(/asset/pics/os-icon-linux.png)
+}
+
 [class^="file-icon-macos"] {
     background-image: url(/asset/pics/os-icon-apple.png)
 }

--- a/templates/downloads.html.ep
+++ b/templates/downloads.html.ep
@@ -41,7 +41,7 @@
       </p>
       <a class="btn btn-dark kick-b" href="<%= url_for 'downloads-rakudo' %>">All releases</a>
       
-      <h5>Use a package manager to install the binary release</h5>
+      <h5>Scoop</h5>
 
       <p>Install Rakudo-on-MoarVM with Scoop:
       <code>scoop install rakudo-moar</code></p>

--- a/templates/downloads.html.ep
+++ b/templates/downloads.html.ep
@@ -31,6 +31,8 @@
     <div class="tab-content">
       <h4>Binary Releases</h4>
       Archives and installers contain a precompiled Rakudo and the Zef module manager.
+      The filenames follow the pattern
+      <code>rakudo-[backend]-[version]-[build revision]-[OS]-[architecture]-[toolchain]</code>
       <p>
       % my $win_files = $binaries->all('rakudo', 'win');
       % if ($win_files->size > 0) {
@@ -70,6 +72,8 @@
     <div class="tab-content">
       <h4>Binary Releases</h4>
       Archives contain a precompiled Rakudo and the Zef module manager.
+      The filenames follow the pattern
+      <code>rakudo-[backend]-[version]-[build revision]-[OS]-[architecture]-[toolchain]</code>
       <p>
       % my $linux_files = $binaries->all('rakudo', 'linux');
       % if ($linux_files->size > 0) {
@@ -133,6 +137,8 @@
     <div class="tab-content">
       <h4>Binary Releases</h4>
       Archives contain a precompiled Rakudo and the Zef module manager.
+      The filenames follow the pattern
+      <code>rakudo-[backend]-[version]-[build revision]-[OS]-[architecture]-[toolchain]</code>
       <p>
       % my $mac_files = $binaries->all('rakudo', 'macos');
       % if ($mac_files->size > 0) {

--- a/templates/downloads.html.ep
+++ b/templates/downloads.html.ep
@@ -45,7 +45,7 @@
 
       <p>Install Rakudo-on-MoarVM with Scoop:
       <code>scoop install rakudo-moar</code></p>
-      <a class="btn btn-dark" href="https://scoop.sh/">Scoop</a>
+      <a class="btn btn-dark kick-b" href="https://scoop.sh/">Scoop</a>
       
       <h4>Rakudo Star Bundle</h4>
 
@@ -55,7 +55,7 @@
       <h5>Chocolatey</h5>
       <p>Install the Rakudo Star Bundle with chocolatey:
       <code>choco install rakudostar</code></p>
-      <a class="btn btn-dark" href="https://chocolatey.org/packages/rakudostar">Chocolatey</a>
+      <a class="btn btn-dark kick-b" href="https://chocolatey.org/packages/rakudostar">Chocolatey</a>
       
       <h5>Scoop</h5>
       <p>Install the Rakudo Star Bundle with Scoop:


### PR DESCRIPTION
- Explain archive filenames. They are not named obviously, so add some explanation.

- Layout: Add some missing spacing

- Name the Scoop entries on the Windows download tab uniformly

- Fix compiled archive file icons. They were previously all recognized as source files.