### PR TITLE
Use rstar instead of Configure.pl when installing from source on linux

### DIFF
--- a/templates/star-source.html.ep
+++ b/templates/star-source.html.ep
@@ -39,18 +39,15 @@ tar -xzf rakudo-star-*.tar.gz
 mv rakudo-star-*/* .
 rm -fr rakudo-star-*
 
-perl Configure.pl --backend=moar --gen-moar
-make
+./bin/rstar install
+
+echo "export PATH=$(pwd)/bin/:$(pwd)/share/perl6/site/bin:$(pwd)/share/perl6/vendor/bin:$(pwd)/share/perl6/core/bin:\$PATH" >> ~/.bashrc
+source ~/.bashrc
 
 # If you wish, you can run the tests
 # Depending on your machine, they could take over half an hour to run
-make rakudo-test
-make rakudo-spectest
-
-make install
-
-echo "export PATH=$(pwd)/install/bin/:$(pwd)/install/share/perl6/site/bin:\$PATH" >> ~/.bashrc
-source ~/.bashrc</code></pre>
+rstar test
+</code></pre>
       </div>
     </div>
   </div


### PR DESCRIPTION
I noticed the latest rakudo-star doesn't bundle Configure.pl but the instruction requires Configure.pl: https://www.rakudo.org/star/source
I think this instruction should remove Configure.pl at least on linux.
I'm not sure the other environments like windows should do so too because their corresponding latest binary package (e.g., .msi) isn't 2021.04 yet (however this instruction suggests to download the source files at 2021.04).