### PR TITLE
Fix pkgsrc text.

### DIFF
--- a/templates/downloads.html.ep
+++ b/templates/downloads.html.ep
@@ -173,7 +173,7 @@
     </label>
     <div class="tab-content">
       <h4>BSD</h4>
-      <p>Pkgsrc.se provides rakudo packages for NetBSD and other BSD flavors.<br/>
+      <p>pkgsrc provides rakudo packages for NetBSD and other Unix flavors.<br/>
       </p>
       <a class="btn btn-dark" href="http://pkgsrc.se/lang/rakudo">pkgsrc.se</a>
     </div>


### PR DESCRIPTION
- They prefer lowercase for pkgsrc.
- Pkgsrc.se is only a search engine for pkgsrc, not the name of the
  project.
- They support also Linux, MacOS, Minix, etc. So, not only for BSDs.