### PR TITLE
[Typo] Remove trailing forward slash on BASH path

### DIFF
--- a/templates/downloads-rakudo-source.html.ep
+++ b/templates/downloads-rakudo-source.html.ep
@@ -176,7 +176,7 @@ make install
 make test
 make spectest
 
-echo "export PATH=$(pwd)/install/bin/:$(pwd)/install/share/perl6/site/bin:\$PATH" \\
+echo "export PATH=$(pwd)/install/bin:$(pwd)/install/share/perl6/site/bin:\$PATH" \\
     >> ~/.bashrc
 source ~/.bashrc</code></pre>
         <p>You'll likely want to also install


### PR DESCRIPTION
I hope this is the right place to make this change. I saw no direct link from the problematic page to the source template.

See: https://github.com/Raku/doc/issues/4091

Thank you.