### PR TITLE
Add nix to star third party

### DIFF
--- a/templates/star-third-party.html.ep
+++ b/templates/star-third-party.html.ep
@@ -59,4 +59,18 @@
       </div>
     </div>
   </div>
+  <div class="col-md-4">
+    <div class="card bg-dark">
+      <div class="card-body">
+        <h5 class="card-title">Nix</h5>
+        <div class="card-text">
+          <p>To try, run: <br> <code>nix-shell -p rakudo</code></p>
+          <p>To install locally, run: <br> <code>nix-env -iA nixpkgs.rakudo</code></p>
+          <p>To install on NixOS, edit <var>/etc/nixos/configuration.nix</var> <br> <code>environment.systemPackages = [ pkgs.rakudo ];
+          <a href="https://nixos.org/"
+            class="btn btn-dark border-secondary">Visit Site</a>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
I've been successfully running and updating it on `nix`.
Unstable version is current at 2025.01
See [Update Request: rakudo 2024.12 → 2025.01](https://github.com/NixOS/nixpkgs/issues/377389#event-16090616609)